### PR TITLE
Fix lost connection after resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## 06/01/2024
+
+### New
+
+- MQTTClient: handles reconnection after disconnection
+
+### Change
+
+- Upgrade packages:
+  - **MQTTNet** from *4.0.0-preview3* to *4.3.0.858*
+  - **Newtonsoft.Json** from *10.0.3* to *13.0.3*
+  - **PlayniteSDK** from *6.2.0* to *6.9.0*
+- Metadata: add link to **simeonradivoev** GitHub project
+- Settings: 
+  - declare variable with the right type
+  - add options for notification and show status changed
+  - group options
+- MQTTClient: use new options to show or not notifications
+
+
+### Fix
+
+- MQTTClient: `WithTls()` is deprecated. Replaced by `WithTlsOptions`
+- MQTTClient: Add an explicit cast for the client declaration
+
+### Log
+
+- *151da59* - feat(MQTTClient): use new settings for displaying message or notifications. Fix can't disconnect after a power resume.
+- *663121c* - feat(Settings): group settings in view. Add settings for display (QoL)
+- *dc16494* - chore(metdata): add link to GitHub
+- *2e32297* - chore csproj file change
+- *d3756e8* - chore: restore code in PowerChange method
+- *558e3dc* - chore: remove unecessary using
+- *2b364d0* - fix: add an explicit cast for CreateMqttClient()
+- *892cf6c* - chore: replace deprecated WIthTLS() method by WithTlsOptions()
+- *17526d8* - chore: update plugin version
+- *98c8a24* - feat: update MQTTnet, Newtonsoft.json and PlayniteSDK packages
+- *f92d85f* - feat: handle disconnection after power resume

--- a/Source/MQTTClient.cs
+++ b/Source/MQTTClient.cs
@@ -6,7 +6,6 @@ using MQTTClient.Helpers;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
-using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
@@ -22,8 +21,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Color = System.Drawing.Color;
-using Image = System.Drawing.Image;
 
 namespace MQTTClient
 {

--- a/Source/MQTTClient.cs
+++ b/Source/MQTTClient.cs
@@ -65,7 +65,7 @@ namespace MQTTClient
             };
 
             applicationClosingCompletionSource = new CancellationTokenSource();
-            client = new MqttFactory().CreateMqttClient();
+            client = (MqttClient)new MqttFactory().CreateMqttClient();
             topicHelper = new TopicHelper(client, settings);
             discoveryModule = new DiscoveryModule(settings, PlayniteApi, topicHelper, client, serializer);
             colorThief = new ColorThief();

--- a/Source/MQTTClient.cs
+++ b/Source/MQTTClient.cs
@@ -164,7 +164,10 @@ namespace MQTTClient
                 }
                 if (settings.Settings.Notifications && client.IsConnected)
                 {
-                    PlayniteApi.Notifications.Add("MQTT Client", "MQTT Connected", NotificationType.Info);
+                    //PlayniteApi.Notifications.Add("MQTT Client", "MQTT Connected", NotificationType.Info);
+                    PlayniteApi.Notifications.Add(
+                        new NotificationMessage(Guid.NewGuid().ToString(), DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss") + "\nMQTT Connected", NotificationType.Info)
+                    );
                 }
                 if (client.IsConnected)
                 {
@@ -220,7 +223,10 @@ namespace MQTTClient
                 StartDisconnect(settings.Settings.ShowStatusChanged).Wait(300);
                 if (settings.Settings.Notifications && !client.IsConnected)
                 {
-                    PlayniteApi.Notifications.Add("MQTT Client", "MQTT Disconnected", NotificationType.Info);
+                    //PlayniteApi.Notifications.Add("MQTT Client", "MQTT Disconnected", NotificationType.Info);
+                    PlayniteApi.Notifications.Add(
+                        new NotificationMessage(Guid.NewGuid().ToString(), DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss") + "\nMQTT Disconnected", NotificationType.Info)
+                    );
                 }
             }
             else
@@ -228,7 +234,10 @@ namespace MQTTClient
                 StartConnection(settings.Settings.ShowStatusChanged);
                 if (settings.Settings.Notifications && client.IsConnected)
                 {
-                    PlayniteApi.Notifications.Add("MQTT Client", "MQTT Connected", NotificationType.Info);
+                    //PlayniteApi.Notifications.Add("MQTT Client", "MQTT Connected", NotificationType.Info);
+                    PlayniteApi.Notifications.Add(
+                        new NotificationMessage(Guid.NewGuid().ToString(), DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss") + "\nMQTT Connected", NotificationType.Info)
+                    );
                 }
             }
         }
@@ -272,8 +281,12 @@ namespace MQTTClient
                 StartDisconnect();
             }
 
-            if (settings.Settings.Notifications)
-                PlayniteApi.Notifications.Add("MQTT Client", "MQTT Disconnected Successfully", NotificationType.Info);
+            if (settings.Settings.Notifications) {
+                //PlayniteApi.Notifications.Add("MQTT Client", "MQTT Disconnected Successfully", NotificationType.Info);
+                PlayniteApi.Notifications.Add(
+                        new NotificationMessage(Guid.NewGuid().ToString(), DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss") + "\nMQTT Disconnected Successfully", NotificationType.Info)
+                    );
+            }
         }
 
         private void ReconnectMenuAction(MainMenuItemActionArgs obj)

--- a/Source/MQTTClient.cs
+++ b/Source/MQTTClient.cs
@@ -535,6 +535,10 @@ namespace MQTTClient
         {
             logger.Debug($"System power mode changed to: {e.Mode}");
             lastPowerMode = e.Mode;
+            if (e.Mode == PowerModes.Resume && !client.IsConnected)
+            {
+                StartConnection();
+            }
         }
 
         public override void OnApplicationStopped(OnApplicationStoppedEventArgs args)

--- a/Source/MQTTClient.cs
+++ b/Source/MQTTClient.cs
@@ -150,7 +150,10 @@ namespace MQTTClient
 
             if (settings.Settings.UseSecureConnection)
             {
-                optionsUnBuilt = optionsUnBuilt.WithTls();
+                optionsUnBuilt = optionsUnBuilt.WithTlsOptions(o =>
+                {
+                    o.UseTls(true);
+                });
             }
 
             var options = optionsUnBuilt.Build();

--- a/Source/MQTTClient.csproj
+++ b/Source/MQTTClient.csproj
@@ -1,104 +1,105 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>MQTTClient</RootNamespace>
-        <AssemblyName>MQTTClient</AssemblyName>
-        <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <Deterministic>true</Deterministic>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="ColorThief.Desktop.v46, Version=1.1.0.1, Culture=neutral, PublicKeyToken=null">
-          <HintPath>packages\ksemenenko.ColorThief.1.1.1.4\lib\net46\ColorThief.Desktop.v46.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="MQTTnet, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
-            <HintPath>packages\MQTTnet.4.0.0-preview3\lib\net461\MQTTnet.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="mscorlib" />
-        <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-          <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="Playnite.SDK, Version=6.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-            <HintPath>packages\PlayniteSDK.6.2.0\lib\net462\Playnite.SDK.dll</HintPath>
-        </Reference>
-        <Reference Include="PresentationCore" />
-        <Reference Include="PresentationFramework" />
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Drawing" />
-        <Reference Include="System.Numerics" />
-        <Reference Include="System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-            <HintPath>C:\Windows\Microsoft.NET\Framework64\v4.0.30319\System.Security.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Xaml" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Xml" />
-        <Reference Include="WindowsBase" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Cenverters.cs" />
-        <Compile Include="Discovery\DiscoveryInfo.cs" />
-        <Compile Include="Discovery\DiscoveryModule.cs" />
-        <Compile Include="Discovery\PlayingGameDiscoveryInfo.cs" />
-        <Compile Include="GameData.cs" />
-        <Compile Include="Helpers\ObjectSerializer.cs" />
-        <Compile Include="Helpers\TopicHelper.cs" />
-        <Compile Include="MQTTClient.cs" />
-        <Compile Include="MQTTClientSettings.cs" />
-        <Compile Include="MQTTClientSettingsView.xaml.cs">
-            <DependentUpon>MQTTClientSettingsView.xaml</DependentUpon>
-        </Compile>
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="Topics.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="extension.yaml">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Include="packages.config" />
-    </ItemGroup>
-    <ItemGroup>
-        <Page Include="MQTTClientSettingsView.xaml">
-            <SubType>Designer</SubType>
-            <Generator>MSBuild:Compile</Generator>
-        </Page>
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="Resources\icon.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MQTTClient</RootNamespace>
+    <AssemblyName>MQTTClient</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ColorThief.Desktop.v46, Version=1.1.0.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\ksemenenko.ColorThief.1.1.1.4\lib\net46\ColorThief.Desktop.v46.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MQTTnet, Version=4.3.0.858, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
+      <HintPath>packages\MQTTnet.4.3.0.858\lib\net461\MQTTnet.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Playnite.SDK, Version=6.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.9.0\lib\net462\Playnite.SDK.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>C:\Windows\Microsoft.NET\Framework64\v4.0.30319\System.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Cenverters.cs" />
+    <Compile Include="Discovery\DiscoveryInfo.cs" />
+    <Compile Include="Discovery\DiscoveryModule.cs" />
+    <Compile Include="Discovery\PlayingGameDiscoveryInfo.cs" />
+    <Compile Include="GameData.cs" />
+    <Compile Include="Helpers\ObjectSerializer.cs" />
+    <Compile Include="Helpers\TopicHelper.cs" />
+    <Compile Include="MQTTClient.cs" />
+    <Compile Include="MQTTClientSettings.cs" />
+    <Compile Include="MQTTClientSettingsView.xaml.cs">
+      <DependentUpon>MQTTClientSettingsView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Topics.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="extension.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="MQTTClientSettingsView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Resources\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/MQTTClientSettings.cs
+++ b/Source/MQTTClientSettings.cs
@@ -33,7 +33,11 @@ namespace MQTTClient
         private bool publishBackground = false;
 
         private bool showProgress = true;
-        
+
+        private bool showStatusChanged = true;
+
+        private bool notifications = true;
+
         public string ClientId
         {
             get => clientId;
@@ -111,6 +115,18 @@ namespace MQTTClient
             get => showProgress;
             set => SetValue(ref showProgress, value);
         }
+
+        public bool ShowStatusChanged
+        {
+            get => showStatusChanged;
+            set => SetValue(ref showStatusChanged, value);
+        }
+
+        public bool Notifications
+        {
+            get => notifications;
+            set => SetValue(ref notifications, value);
+        }
     }
 
     public class MQTTClientSettingsViewModel : ObservableObject, ISettings
@@ -135,7 +151,7 @@ namespace MQTTClient
             this.plugin = plugin;
 
             // Load saved settings.
-            var savedSettings = plugin.LoadPluginSettings<MQTTClientSettings>();
+            MQTTClientSettings savedSettings = plugin.LoadPluginSettings<MQTTClientSettings>();
 
             // LoadPluginSettings returns null if not saved data is available.
             if (savedSettings != null)

--- a/Source/MQTTClientSettingsView.xaml
+++ b/Source/MQTTClientSettingsView.xaml
@@ -10,34 +10,55 @@
     <TabControl ClipToBounds="True" MaxHeight="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Panel}}, Path=ActualHeight, Mode=OneWay}">
             <TabItem Header="General">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="Client Name:" />
-                        <TextBox Text="{Binding Settings.ClientId}" />
-                        <TextBlock Text="MQTT Server Address:" />
-                        <TextBox Text="{Binding Settings.ServerAddress}" />
-                        <StackPanel Orientation="Horizontal">
-                            <CheckBox IsChecked="{Binding Settings.UseSecureConnection}" Margin="5" />
-                            <TextBlock Text="Secure TCP Connection:" VerticalAlignment="Center" />
+                <StackPanel Margin="10">
+                    <GroupBox BorderThickness="2">
+                        <GroupBox.Header>
+                            <Label FontWeight="Bold">MQTT Client</Label>
+                        </GroupBox.Header>
+                        <StackPanel>
+                            <TextBlock Text="Client Name:" />
+                            <TextBox Text="{Binding Settings.ClientId}" />
                         </StackPanel>
-                        <TextBlock Text="MQTT Server Port:" />
-                        <TextBox PreviewTextInput="NumberValidationTextBox">
-                            <TextBox.Text>
-                                <Binding Path="Settings.Port"
-                                         UpdateSourceTrigger="PropertyChanged"
-                                         ValidatesOnDataErrors="True"
-                                         NotifyOnValidationError="True"
-                                         Converter="{mqttClient:NullableUIntToStringConverter}" />
-                            </TextBox.Text>
-                        </TextBox>
-                        <TextBlock Text="Username:" />
-                        <TextBox Text="{Binding Settings.Username}" />
-                        <TextBlock Text="Password:" />
-                        <PasswordBox Name="PasswordBox" PasswordChanged="PasswordBox_OnPasswordChanged" />
-                        <StackPanel Orientation="Horizontal" ToolTip="Should a popup showing progress and allowing canceling show on each playnite start.">
-                            <CheckBox IsChecked="{Binding Settings.ShowProgress}" Margin="5"></CheckBox>
-                            <TextBlock Text="Show Progress On Startup:" VerticalAlignment="Center" />
+                    </GroupBox>
+                    <GroupBox BorderThickness="2">
+                        <GroupBox.Header>
+                            <Label FontWeight="Bold">MQTT Server</Label>
+                        </GroupBox.Header>
+                        <StackPanel>
+                            <TextBlock Text="MQTT Server Address:" />
+                            <TextBox Text="{Binding Settings.ServerAddress}" />
+                            <TextBlock Text="MQTT Server Port:" />
+                            <TextBox PreviewTextInput="NumberValidationTextBox" Text="{Binding Settings.Port, Converter={mqttClient:NullableUIntToStringConverter}, NotifyOnValidationError=True, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
+                            <StackPanel Orientation="Horizontal">
+                                <CheckBox IsChecked="{Binding Settings.UseSecureConnection}" Margin="5" />
+                                <TextBlock Text="Secure TCP Connection" VerticalAlignment="Center" />
+                            </StackPanel>
+                            <TextBlock Text="Username:" />
+                            <TextBox Text="{Binding Settings.Username}" />
+                            <TextBlock Text="Password:" />
+                            <PasswordBox x:Name="PasswordBox" PasswordChanged="PasswordBox_OnPasswordChanged" />
                         </StackPanel>
-                    </StackPanel>
+                    </GroupBox>
+                    <GroupBox BorderThickness="2">
+                        <GroupBox.Header>
+                            <Label FontWeight="Bold">Display</Label>
+                        </GroupBox.Header>
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" ToolTip="Should a popup showing progress and allowing canceling show on each playnite start.">
+                                <CheckBox IsChecked="{Binding Settings.ShowProgress}" Margin="5"/>
+                                <TextBlock Text="Show Progress On Startup" VerticalAlignment="Center" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" ToolTip="Should a popup showing status changed">
+                                <CheckBox IsChecked="{Binding Settings.ShowStatusChanged}" Margin="5"/>
+                                <TextBlock Text="Show Status Changed" VerticalAlignment="Center" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" ToolTip="Should a notification be created">
+                                <CheckBox IsChecked="{Binding Settings.Notifications}" Margin="5"/>
+                                <TextBlock Text="Notification" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </StackPanel>
+                    </GroupBox>
+                </StackPanel>
                 </ScrollViewer>
             </TabItem>
             <TabItem Header="Topics">
@@ -57,15 +78,15 @@
                     <StackPanel Margin="10">
                         <StackPanel Orientation="Horizontal" ToolTip="Should the dominant color of the cover be published as hue, saturation and brightness">
                             <CheckBox IsChecked="{Binding Settings.PublishCoverColors}" Margin="5"></CheckBox>
-                            <TextBlock Text="Publish Cover Colors:" VerticalAlignment="Center" />
+                            <TextBlock Text="Publish Cover Colors" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" ToolTip="Should the cover image be published for selected games and currently playing games">
                             <CheckBox IsChecked="{Binding Settings.PublishCover}" Margin="5"></CheckBox>
-                            <TextBlock Text="Publish Cover:" VerticalAlignment="Center" />
+                            <TextBlock Text="Publish Cover" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" ToolTip="Should the background image be published for currently playing games">
                             <CheckBox IsChecked="{Binding Settings.PublishBackground}" Margin="5"></CheckBox>
-                            <TextBlock Text="Publish Background:" VerticalAlignment="Center" />
+                            <TextBlock Text="Publish Background" VerticalAlignment="Center" />
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>

--- a/Source/extension.yaml
+++ b/Source/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: MQTTClient_90c44048-4f8f-43f7-a0c1-f8164bf1d7ef
 Name: MQTT Client
 Author: Simeon Radivoev
-Version: 1.1.0
+Version: 1.2.0
 Icon: Resources/icon.png
 Module: MQTTClient.dll
 Type: GenericPlugin

--- a/Source/extension.yaml
+++ b/Source/extension.yaml
@@ -8,3 +8,5 @@ Type: GenericPlugin
 Links:
   - Name: Website
     URL: https://simeonradivoev.com
+  - Name: Github
+    URL: https://github.com/simeonradivoev/PlayniteMQTTClient

--- a/Source/packages.config
+++ b/Source/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MQTTnet" version="4.0.0-preview3" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.2.0" targetFramework="net462" />
   <package id="ksemenenko.ColorThief" version="1.1.1.4" targetFramework="net462" />
+  <package id="MQTTnet" version="4.3.0.858" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.9.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
# Fix lost connection after resume

I've also made a few additions to the parameters

Below all the changes (in the CHANGELOG.md file too)

## New

- MQTTClient: handles reconnection after disconnection

## Change

- Upgrade packages:
  - **MQTTNet** from *4.0.0-preview3* to *4.3.0.858*
  - **Newtonsoft.Json** from *10.0.3* to *13.0.3*
  - **PlayniteSDK** from *6.2.0* to *6.9.0*
- Metadata: add link to **simeonradivoev** GitHub project
- Settings: 
  - declare variable with the right type
  - add options for notification and show status changed
  - group options
- MQTTClient: use new options to show or not notifications


## Fix

- MQTTClient: `WithTls()` is deprecated. Replaced by `WithTlsOptions`
- MQTTClient: Add an explicit cast for the client declaration

## Log

- *151da59* - feat(MQTTClient): use new settings for displaying message or notifications. Fix can't disconnect after a power resume.
- *663121c* - feat(Settings): group settings in view. Add settings for display (QoL)
- *dc16494* - chore(metdata): add link to GitHub
- *2e32297* - chore csproj file change
- *d3756e8* - chore: restore code in PowerChange method
- *558e3dc* - chore: remove unecessary using
- *2b364d0* - fix: add an explicit cast for CreateMqttClient()
- *892cf6c* - chore: replace deprecated WIthTLS() method by WithTlsOptions()
- *17526d8* - chore: update plugin version
- *98c8a24* - feat: update MQTTnet, Newtonsoft.json and PlayniteSDK packages
- *f92d85f* - feat: handle disconnection after power resume